### PR TITLE
Fix fetch API mismatch

### DIFF
--- a/Distributed_Web_Crawler_Design/main.py
+++ b/Distributed_Web_Crawler_Design/main.py
@@ -118,12 +118,12 @@ class DataProcessor:
 
     def handle_url(self, url):
         # This method is run in a new thread for each URL consumed from Kafka
-        fetched_results = self.fetcher.fetch()
-        for fetched_data, new_urls in fetched_results:
-            if fetched_data is None:
-                logging.error(f"Failed to fetch and process {url} after retries.")
-            self.send_urls_to_kafka(new_urls)
-            self.store_data_in_cassandra(url, fetched_data)
+        fetched_data, new_urls = self.fetcher.fetch(url)
+        if fetched_data is None:
+            logging.error(f"Failed to fetch and process {url} after retries.")
+            return
+        self.send_urls_to_kafka(new_urls)
+        self.store_data_in_cassandra(url, fetched_data)
 
     def consume_urls_from_kafka(self, max_threads=10):
         # Consume URLs from Kafka and process them

--- a/Distributed_Web_Crawler_Design/url_fetcher.py
+++ b/Distributed_Web_Crawler_Design/url_fetcher.py
@@ -64,7 +64,19 @@ class URLFetcher:
         time.sleep(random.uniform(0.5, 1.5))
         return data
 
-    def fetch(self, max_threads=10):
+    def fetch(self, url):
+        """Fetch a single URL and return the scraped data along with new URLs."""
+        data = self.fetch_with_retry(url)
+        if data is None:
+            return None, []
+
+        # Generate new URLs from the "Similar Apps" section if available
+        similar = data.get('Similar Apps', {})
+        new_urls = [self.base_url.format(app_id) for app_id in similar.keys()]
+
+        return data, new_urls
+
+    def fetch_all(self, max_threads=10):
         new_urls = []
         with open('ids.txt', 'r') as f:
             for line in f:


### PR DESCRIPTION
## Summary
- implement single URL fetch in `url_fetcher.py`
- update `DataProcessor.handle_url` to use the new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6841227516f8832e9efd9cf68b114adb